### PR TITLE
Add option to disable perltidy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.5.3 2019-03-29
+  - Add option to disable perltidy. Thanks to pmb0.
+
 0.5.2 2018-12-07
   - Partial support for virtual filesystems like SSH FS (without support of .perltidyrc from virtual fs). Thanks to j-ecko.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This perltidy has some extended features:
 - It can format large perl files (in my case sfodje extension had 10 or 20 KB file limit. I don't know why it happened).
 - It can format selected text.
 - Partial support for virtual filesystems like SSH FS (without support of .perltidyrc from virtual fs).
+- Option to enable perltidy only with existing .perltidyrc in project.
 
 Alternatives
 1. [sfodje perltidy](https://github.com/sfodje/perltidy).

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.5.2",
   "publisher": "Kaktus",
   "engines": {
-    "vscode": "^1.11.0"
+    "vscode": "^1.23.0"
   },
   "categories": [
     "Formatters"
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "typescript": "^2.0.3",
-    "vscode": "^1.0.0",
+    "vscode": "^1.1.30",
     "mocha": "^2.3.3",
     "@types/node": "^6.0.40",
     "@types/mocha": "^2.2.32"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "perltidy-more",
   "displayName": "perltidy-more",
   "description": "Extended perltidy",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "publisher": "Kaktus",
   "engines": {
     "vscode": "^1.23.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
       "type": "object",
       "title": "perltidy-more configuration",
       "properties": {
+        "perltidy-more.autoDisable": {
+          "type": "boolean",
+          "description": "Disable perltidy for projects without a local .perltidyrc"
+        },
         "perltidy-more.executable": {
           "type": "string",
           "default": "perltidy",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,8 @@
 
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
+import { existsSync } from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
   function get_range(document: vscode.TextDocument, range: vscode.Range, selection: vscode.Selection) {
@@ -28,6 +29,17 @@ export function activate(context: vscode.ExtensionContext) {
     let executable = config.get('executable', '');
     let profile = config.get('profile', '');
 
+
+    let currentWorkspaceFolder = vscode.workspace.getWorkspaceFolder(
+      vscode.window.activeTextEditor.document.uri
+    ).uri.path;
+
+    if (config.get('autoDisable', false)) {
+      if (!existsSync(join(currentWorkspaceFolder, profile || '.perltidyrc'))) {
+        return;
+      }
+    }
+
     let args: string[] = ["-st"];
 
     if (profile) {
@@ -35,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     let options = {
-      cwd: dirname(document.uri.fsPath)
+      cwd: currentWorkspaceFolder
     };
 
     // Support for spawn at virtual filesystems

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,13 +29,12 @@ export function activate(context: vscode.ExtensionContext) {
     let executable = config.get('executable', '');
     let profile = config.get('profile', '');
 
+    let currentWorkspace = vscode.workspace.getWorkspaceFolder(
+      document.uri
+    )
 
-    let currentWorkspaceFolder = vscode.workspace.getWorkspaceFolder(
-      vscode.window.activeTextEditor.document.uri
-    ).uri.path;
-
-    if (config.get('autoDisable', false)) {
-      if (!existsSync(join(currentWorkspaceFolder, profile || '.perltidyrc'))) {
+    if (config.get('autoDisable', false) && currentWorkspace!=null) {
+      if (!existsSync(join(currentWorkspace.uri.path, '.perltidyrc'))) {
         return;
       }
     }
@@ -47,7 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     let options = {
-      cwd: currentWorkspaceFolder
+      cwd: dirname(document.uri.fsPath)
     };
 
     // Support for spawn at virtual filesystems


### PR DESCRIPTION
This Pull Request adds an option `autoDisable`. If the option is checked, `perltidy` will not run in projects without a local `.perltidyrc`. This replicates the behavior of other tools like `eslint`.