### PR TITLE
Support formatOnType

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
+  const selector = ['perl', 'perl+mojolicious'];
   function get_range(document: vscode.TextDocument, range: vscode.Range, selection: vscode.Selection) {
     if (!(selection === null) && !selection.isEmpty) {
       range = new vscode.Range(selection.start, selection.end);
@@ -77,7 +78,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
   }
 
-  let provider = vscode.languages.registerDocumentRangeFormattingEditProvider(['perl', 'perl+mojolicious'], {
+  let provider = vscode.languages.registerDocumentRangeFormattingEditProvider(selector, {
     provideDocumentRangeFormattingEdits: (document, range, options, token) => {
       return new Promise((resolve, reject) => {
         range = get_range(document, range, null);
@@ -97,7 +98,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  let formatOnTypeProvider = vscode.languages.registerOnTypeFormattingEditProvider(['perl', 'perl+mojolicious'], {
+  let formatOnTypeProvider = vscode.languages.registerOnTypeFormattingEditProvider(selector, {
     provideOnTypeFormattingEdits: (document, position, ch, options, token) => {
       return new Promise((resolve, reject) => {
         // Determine start position. start format from the next line of the previous ';'.


### PR DESCRIPTION
Hi, I implemented `OnTypeFormattingEditProvider` to support formatOnType.

> editor.formatOnType - Format the line after typing.
https://code.visualstudio.com/docs/editor/codebasics

With setting `editor.formatOnType` true, This extension will format the current statement when we type ;, ], } and ).

### GIF

![how this pull request works](https://user-images.githubusercontent.com/18360/68017498-33953f80-fcda-11e9-88b1-5889d64f0f3c.gif)

