### PR TITLE
When executable starts from `.`, set cwd to the current workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.6.1 2019-11-26
+  - Support for relative path to perltidy binary. Thanks to @hitode909.
+
 0.6.0 2019-11-03
   - FormatOnType support. Thanks to @hitode909.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This perltidy has some extended features:
 - Partial support for virtual filesystems like SSH FS (without support of .perltidyrc from virtual fs).
 - Option to enable perltidy only with existing .perltidyrc in project.
 - FormatOnType support (you can enable it in settings).
+- Support for relative path to perltidy binary. Set perltidy-more.executable to relative path and it will be search it in workspace folder.
 
 Alternatives
 1. [sfodje perltidy](https://github.com/sfodje/perltidy).
@@ -32,3 +33,12 @@ If this extension does not work:
 ### 1. Q: I'd like to use .perltidyrc specific to different projects.
 
 A: Use "perltidy-more.profile" option and set it to ".../.perltidyrc". Three dots is perltidy specific option to indicates that the file should be searched for starting in the current directory and working upwards. This makes it easier to have multiple projects each with their own .perltidyrc in their root directories.
+
+### 2. Q: I'd like to run perltidy in docker container.
+
+A: Use shell script like this and set it as perltidy-more.executable in options
+
+```
+#!/usr/bin/env sh
+exec docker run --rm -i -v "$PWD":/app -w /app avastsoftware/perltidy $@
+```

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,11 @@ export function activate(context: vscode.ExtensionContext) {
       options.cwd = ".";
     }
 
+    // Support for executing relative path script from the current workspace. eg: ./script/perltidy-wrapper.pl
+    if (executable[0] === '.') {
+      options.cwd = currentWorkspace.uri.path;
+    }
+
     return new Promise((resolve, reject) => {
       try {
         let worker = spawn(executable, args, options);


### PR DESCRIPTION
@kak-tus Hi! This pull request fixes #9, it works fine for me.