### PR TITLE
Improve format selection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,6 +94,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   let provider = vscode.languages.registerDocumentRangeFormattingEditProvider(selector, {
     provideDocumentRangeFormattingEdits: (document, range, options, token) => {
+      // To keep indent level, expand the range to include the beginning of the line.
+      // "  [do {]" -> "[  do {]"
+      //
+      // Don't expand if there is a non-whitespace character between the beginning of the line and the range
+      // "return [do {]" -> "return [do {]"
+      const indentRange = new vscode.Range(new vscode.Position(range.start.line, 0), range.start);
+      if (document.getText(indentRange).match(/^\s*$/)) {
+        range = new vscode.Range(new vscode.Position(range.start.line, 0), range.end);
+      }
+
       return new Promise((resolve, reject) => {
         range = get_range(document, range, null);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,14 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }
 
-    let args: string[] = ["-st"];
+    let args: string[] = [
+      "--standard-output",
+      // Terminal newline causes a problem when formatting selection.
+      // We cannot determine whether the terminal newline is from original code, or appended by perltidy.
+      // With terminal newline: "foo\n" -> "foo\n", "foo" -> "foo\n"
+      // Expected result:       "foo\n" -> "foo\n", "foo" -> "foo"
+      "-no-add-terminal-newline",
+    ];
 
     if (profile) {
       args.push("--profile=" + profile);
@@ -82,7 +89,6 @@ export function activate(context: vscode.ExtensionContext) {
           result_text += chunk;
         });
         worker.stdout.on('end', () => {
-          result_text.trim();
           resolve(result_text);
         });
       }
@@ -151,8 +157,7 @@ export function activate(context: vscode.ExtensionContext) {
             return;
           }
           const result: vscode.TextEdit[] = [];
-          // remove last newsline
-          result.push(new vscode.TextEdit(range, res.replace(/\n$/, '')));
+          result.push(new vscode.TextEdit(range, res));
           resolve(result);
         });
       });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   function tidy(document: vscode.TextDocument, range: vscode.Range) {
     let text = document.getText(range);
-    if (!text || text.length === 0) return;
+    if (!text || text.length === 0) return new Promise((resolve) => { resolve('') });
 
     let config = vscode.workspace.getConfiguration('perltidy-more');
 


### PR DESCRIPTION
Hi! Thank you for great extension, I use this extension everyday.

I encountered a problem when formatting selection.
- Indent level is back to 0.
  - Fixed in 94c810f40d353688abb4b61c254292f0240c6c07
- Terminal newline is appended.
  - Fixed in 0907ccb136b817266ec066f597207068cc7bd59c

On this branch, now this extension supports only modified text option(https://code.visualstudio.com/updates/v1_49#_only-format-modified-text).
In this mode, format is called many time for every modified ranges, so keeping indent and keeping terminal newline are important.
To support this option, formatting empty string is required, so I added commit 6f0c08c1976be4cd855cdc0bcbca0f8fcc52536e.

## before formatting

![code](https://user-images.githubusercontent.com/18360/132798659-5cb7381e-c77e-49cd-b2f5-97a6455b49b8.png)


## on master branch

![master](https://user-images.githubusercontent.com/18360/132798690-3e135d93-2ad7-430c-8e4d-39b80ba1bfdf.png)

## on this branch

![after](https://user-images.githubusercontent.com/18360/132798707-cb3c3b77-da7e-401c-96ec-9d33ea664959.png)


<hr/>

By the way, dependencies seems broken with latest versions. When I pin packages, It works fine for me.
```diff
diff --git a/package.json b/package.json
index aecaae5..a6798e9 100644
--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
-    "typescript": "^2.0.3",
+    "typescript": "2.0.3",
     "vscode": "^1.1.30",
-    "mocha": "^2.3.3",
-    "@types/node": "^6.0.40",
-    "@types/mocha": "^2.2.32"
+    "mocha": "2.3.3",
+    "@types/node": "6.0.40",
+    "@types/mocha": "2.2.32"
   },
   "repository": {
     "type": "git",

```

