### PR TITLE
Fix `npm run compile`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "^4.4.3",
     "vscode": "^1.1.30",
     "mocha": "^2.3.3",
-    "@types/node": "^6.0.40",
+    "@types/node": "^16.9.6",
     "@types/mocha": "^2.2.32"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
-    "typescript": "^2.0.3",
+    "typescript": "^4.4.3",
     "vscode": "^1.1.30",
     "mocha": "^2.3.3",
     "@types/node": "^6.0.40",


### PR DESCRIPTION
close: https://github.com/kak-tus/perltidy-more/issues/13

I don't know the details, but it seemed that `npm run compile` was failing due to low versions of `typescript` and `@types/node`. So I fixed it by upgrading the versions of each package.

## Compatibility
Since this is only a fix for compile-time type errors, there is no impact on compatibility. You can safely apply the fix.

## How to check
before:
```console
$ # In order to get the most recent version of the library possible, you need to delete the lock file
$ rm package-lock.json
$ npm install

$ npm run compile --loglevel silent
[14:17:36] Starting compilation in watch mode...

node_modules/@types/node/index.d.ts:20:1 - error TS1084: Invalid 'reference' directive syntax.

20 /// <reference lib="es2015" />
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[14:17:36] Found 1 error. Watching for file changes.
```

after:
```console
$ # In order to get the most recent version of the library possible, you need to delete the lock file
$ rm package-lock.json
$ npm install

$ npm run compile --loglevel silent
[15:08:23] Starting compilation in watch mode...

[15:08:25] Found 0 errors. Watching for file changes.
```