### PR TITLE
Improve error handling

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,2 +1,13 @@
+import * as vscode from 'vscode';
+
 /** Error indicating formatting failure. */
 export class FormatError extends Error {}
+
+/** Handle error thrown from `tidy` function */
+export function handleTidyError (error: unknown) {
+  if (error instanceof FormatError) {
+    vscode.window.showErrorMessage(error.message);
+  } else {
+    vscode.window.showErrorMessage(`Internal error: ${error}`);
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,2 @@
+/** Error indicating formatting failure. */
+export class FormatError extends Error {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,6 @@ export function activate(context: vscode.ExtensionContext) {
 
         let promise = tidy(document, range);
         if (!promise) {
-          reject();
           return;
         }
 
@@ -161,13 +160,11 @@ export function activate(context: vscode.ExtensionContext) {
 
         const promise = tidy(document, range);
         if (!promise) {
-          reject();
           return;
         }
 
         promise.then((res: string) => {
           if (token.isCancellationRequested) {
-            reject();
             return;
           }
           const result: vscode.TextEdit[] = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,9 +128,6 @@ export function activate(context: vscode.ExtensionContext) {
         range = get_range(document, range, null);
 
         let promise = tidy(document, range);
-        if (!promise) {
-          return;
-        }
 
         promise.then((res: string) => {
           let result: vscode.TextEdit[] = [];
@@ -159,9 +156,6 @@ export function activate(context: vscode.ExtensionContext) {
         const range = new vscode.Range(start, position);
 
         const promise = tidy(document, range);
-        if (!promise) {
-          return;
-        }
 
         promise.then((res: string) => {
           if (token.isCancellationRequested) {
@@ -187,9 +181,6 @@ export function activate(context: vscode.ExtensionContext) {
     let range = get_range(document, null, selection);
 
     let promise = tidy(document, range);
-    if (!promise) {
-      return;
-    }
 
     promise.then((res: string) => {
       editor.edit((builder: vscode.TextEditorEdit) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
       return Promise.resolve(undefined);
     }
 
-    if (config.get('autoDisable', false) && currentWorkspace != null) {
+    if (config.get('autoDisable', false)) {
       if (!existsSync(join(currentWorkspace.uri.path, '.perltidyrc'))) {
         // Failed to format because `.perltidyrc` not found.
         return Promise.resolve(undefined);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,9 +37,15 @@ export function activate(context: vscode.ExtensionContext) {
     var executable = config.get('executable', '');
     let profile = config.get('profile', '');
 
-    let currentWorkspace = vscode.workspace.getWorkspaceFolder(
+    const currentWorkspace = vscode.workspace.getWorkspaceFolder(
       document.uri
     )
+
+    if (currentWorkspace === undefined) {
+      // Failed to format because this extension does not support
+      // to format files that do not belong to a workspace.
+      return Promise.resolve(undefined);
+    }
 
     if (config.get('autoDisable', false) && currentWorkspace != null) {
       if (!existsSync(join(currentWorkspace.uri.path, '.perltidyrc'))) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 import { dirname, join, isAbsolute } from 'path';
 import { existsSync } from 'fs';
-import { FormatError } from './error';
+import { FormatError, handleTidyError } from './error';
 
 export function activate(context: vscode.ExtensionContext) {
   const selector = ['perl', 'perl+mojolicious'];
@@ -137,7 +137,7 @@ export function activate(context: vscode.ExtensionContext) {
           let result: vscode.TextEdit[] = [];
           result.push(new vscode.TextEdit(range, res));
           resolve(result);
-        });
+        }).catch(handleTidyError);
       });
     }
   });
@@ -173,7 +173,7 @@ export function activate(context: vscode.ExtensionContext) {
           const result: vscode.TextEdit[] = [];
           result.push(new vscode.TextEdit(range, res));
           resolve(result);
-        });
+        }).catch(handleTidyError);
       });
     }
   }, ';', '}', ')', ']');
@@ -198,7 +198,7 @@ export function activate(context: vscode.ExtensionContext) {
       editor.edit((builder: vscode.TextEditorEdit) => {
         builder.replace(range, res);
       });
-    });
+    }).catch(handleTidyError);
   });
 
   context.subscriptions.push(provider);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,14 @@ export function activate(context: vscode.ExtensionContext) {
     return range;
   }
 
-  function tidy(document: vscode.TextDocument, range: vscode.Range) {
+  /**
+   * format text by perltidy.
+   * @param document Documents containing text 
+   * @param range Range of text
+   * @returns Returns the formatted text. However, if the formatting fails due to incorrect configuration, etc.,
+   * `undefined` will be returned.
+   */
+  function tidy(document: vscode.TextDocument, range: vscode.Range): Promise<string | undefined> {
     let text = document.getText(range);
     if (!text || text.length === 0) return new Promise((resolve) => { resolve('') });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { FormatError } from './error';
 
 export function activate(context: vscode.ExtensionContext) {
   const selector = ['perl', 'perl+mojolicious'];
-  function get_range(document: vscode.TextDocument, range: vscode.Range, selection: vscode.Selection) {
+  function get_range(document: vscode.TextDocument, range: vscode.Range | null, selection: vscode.Selection | null) {
     if (!(selection === null) && !selection.isEmpty) {
       range = new vscode.Range(selection.start, selection.end);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
    * @param range Range of text
    * @returns Returns the formatted text.
    * @throws {import('./error').FormatError} Throw an error if failed to format.
+   * @throws {unknown} Throw an error an unexpected problem has occurred.
    */
   function tidy(document: vscode.TextDocument, range: vscode.Range): Promise<string> {
     let text = document.getText(range);
@@ -105,6 +106,7 @@ export function activate(context: vscode.ExtensionContext) {
         });
       }
       catch (error) {
+        // internal error
         reject(error);
       }
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,7 +177,7 @@ export function activate(context: vscode.ExtensionContext) {
   }, ';', '}', ')', ']');
 
   let command = vscode.commands.registerCommand('perltidy-more.tidy', () => {
-    let editor = vscode.window.activeTextEditor;
+    const editor = vscode.window.activeTextEditor;
     if (!editor) {
       return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (config.get('autoDisable', false) && currentWorkspace != null) {
       if (!existsSync(join(currentWorkspace.uri.path, '.perltidyrc'))) {
-        return;
+        // Failed to format because `.perltidyrc` not found.
+        return Promise.resolve(undefined);
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": [
       "es6"
     ],
+    "strict": true,
     "sourceMap": true,
     "rootDir": "."
   },


### PR DESCRIPTION
## Problem

Currently, if the file formatting fails for some reason, perltidy-more does nothing. It will not format the file, and will not log the cause of the failure. This is inconvenient because the user cannot find out why the formatting failed.

## Solution (This PR)
If the formatting fails due to user error or perltidy internal error, the error will be notified to the user via dialog.

What I did:
- Change the return type of `tidy` function from `undefined | Promise<string>` to `Promise<undefined>`.
- If `tidy` function throws an error, the user will be notified with a dialog.
- If `tidy` function returns `undefined`, skip formatting without displaying a dialog.

## Confirm the operation
I have confirmed that the behavior is as expected in my environment.

- [x] The entire file can be formatted from `F1 > Format Document`.
- [x] The selected text can be formatted from `Context Menu > Format Selection`.
- [x] The line can be formatted inserting a semicolon if `editor.formatOnType` is `true`.
- [x] The error dialog is shown when trying to format a file that does not belong to a workspace.
- [x] The dialog will not be displayed and formatting will be skipped if `autoDisable` is `true` and `.perltidyrc` does not exist.

<img width="1007" alt="スクリーンショット 2021-09-26 18 15 22" src="https://user-images.githubusercontent.com/9639995/134801521-e6faf115-5a1b-4208-83fa-70b3764c2352.png">


