### PR TITLE
Improve spawn's error handling

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -11,3 +11,8 @@ export function handleTidyError (error: unknown) {
     vscode.window.showErrorMessage(`Internal error: ${error}`);
   }
 }
+
+/** Whether the error is compatible with `NodeJS.ErrnoException` or not. */
+export function isErrnoException (e: unknown): e is NodeJS.ErrnoException {
+  return e instanceof Error;
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,2 +1,13 @@
+import * as vscode from 'vscode';
+
 /** Error indicating formatting failure. */
 export class FormatError extends Error {}
+
+/** Handle error thrown from `tidy` function */
+export function handleTidyError (error: unknown) {
+  if (error instanceof FormatError) {
+    vscode.window.showErrorMessage(error.message);
+  } else {
+    vscode.window.showErrorMessage(`Internal error: ${error}`);
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,2 @@
+/** Error indicating formatting failure. */
+export class FormatError extends Error {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,6 @@ export function activate(context: vscode.ExtensionContext) {
 
         let promise = tidy(document, range);
         if (!promise) {
-          reject();
           return;
         }
 
@@ -161,13 +160,11 @@ export function activate(context: vscode.ExtensionContext) {
 
         const promise = tidy(document, range);
         if (!promise) {
-          reject();
           return;
         }
 
         promise.then((res: string) => {
           if (token.isCancellationRequested) {
-            reject();
             return;
           }
           const result: vscode.TextEdit[] = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,9 +128,6 @@ export function activate(context: vscode.ExtensionContext) {
         range = get_range(document, range, null);
 
         let promise = tidy(document, range);
-        if (!promise) {
-          return;
-        }
 
         promise.then((res: string) => {
           let result: vscode.TextEdit[] = [];
@@ -159,9 +156,6 @@ export function activate(context: vscode.ExtensionContext) {
         const range = new vscode.Range(start, position);
 
         const promise = tidy(document, range);
-        if (!promise) {
-          return;
-        }
 
         promise.then((res: string) => {
           if (token.isCancellationRequested) {
@@ -187,9 +181,6 @@ export function activate(context: vscode.ExtensionContext) {
     let range = get_range(document, null, selection);
 
     let promise = tidy(document, range);
-    if (!promise) {
-      return;
-    }
 
     promise.then((res: string) => {
       editor.edit((builder: vscode.TextEditorEdit) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,6 +98,10 @@ export function activate(context: vscode.ExtensionContext) {
 
         let result_text = '';
 
+        worker.on('error', (e) => {
+          reject(e);
+        });
+
         worker.stdout.on('data', (chunk) => {
           result_text += chunk;
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
       return Promise.resolve(undefined);
     }
 
-    if (config.get('autoDisable', false) && currentWorkspace != null) {
+    if (config.get('autoDisable', false)) {
       if (!existsSync(join(currentWorkspace.uri.path, '.perltidyrc'))) {
         // Failed to format because `.perltidyrc` not found.
         return Promise.resolve(undefined);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,9 +37,15 @@ export function activate(context: vscode.ExtensionContext) {
     var executable = config.get('executable', '');
     let profile = config.get('profile', '');
 
-    let currentWorkspace = vscode.workspace.getWorkspaceFolder(
+    const currentWorkspace = vscode.workspace.getWorkspaceFolder(
       document.uri
     )
+
+    if (currentWorkspace === undefined) {
+      // Failed to format because this extension does not support
+      // to format files that do not belong to a workspace.
+      return Promise.resolve(undefined);
+    }
 
     if (config.get('autoDisable', false) && currentWorkspace != null) {
       if (!existsSync(join(currentWorkspace.uri.path, '.perltidyrc'))) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 import { dirname, join, isAbsolute } from 'path';
 import { existsSync } from 'fs';
-import { FormatError } from './error';
+import { FormatError, handleTidyError } from './error';
 
 export function activate(context: vscode.ExtensionContext) {
   const selector = ['perl', 'perl+mojolicious'];
@@ -137,7 +137,7 @@ export function activate(context: vscode.ExtensionContext) {
           let result: vscode.TextEdit[] = [];
           result.push(new vscode.TextEdit(range, res));
           resolve(result);
-        });
+        }).catch(handleTidyError);
       });
     }
   });
@@ -173,7 +173,7 @@ export function activate(context: vscode.ExtensionContext) {
           const result: vscode.TextEdit[] = [];
           result.push(new vscode.TextEdit(range, res));
           resolve(result);
-        });
+        }).catch(handleTidyError);
       });
     }
   }, ';', '}', ')', ']');
@@ -198,7 +198,7 @@ export function activate(context: vscode.ExtensionContext) {
       editor.edit((builder: vscode.TextEditorEdit) => {
         builder.replace(range, res);
       });
-    });
+    }).catch(handleTidyError);
   });
 
   context.subscriptions.push(provider);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,14 @@ export function activate(context: vscode.ExtensionContext) {
     return range;
   }
 
-  function tidy(document: vscode.TextDocument, range: vscode.Range) {
+  /**
+   * format text by perltidy.
+   * @param document Documents containing text 
+   * @param range Range of text
+   * @returns Returns the formatted text. However, if the formatting fails due to incorrect configuration, etc.,
+   * `undefined` will be returned.
+   */
+  function tidy(document: vscode.TextDocument, range: vscode.Range): Promise<string | undefined> {
     let text = document.getText(range);
     if (!text || text.length === 0) return new Promise((resolve) => { resolve('') });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,6 +100,8 @@ export function activate(context: vscode.ExtensionContext) {
         let error_text = '';
 
         worker.on('error', (e) => {
+          // When the process fails to start, terminate, or send a message to the process
+          // ref: https://nodejs.org/api/child_process.html#child_process_event_error
           if (isErrnoException(e) && e.code === 'ENOENT') {
             if (executable === 'perltidy') {
               reject(new FormatError(`Format failed. Executable file (\`${executable}\`) is not found. You probably forgot to install perltidy.`));
@@ -120,6 +122,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         worker.on('close', (code) => {
           if (code !== 0) {
+            // ref: http://perltidy.sourceforge.net/perltidy.html#ERROR-HANDLING
             if (error_text === '') {
               reject(new FormatError(`Format failed. Perltidy exited with exit code ${code}.`));
             } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { FormatError } from './error';
 
 export function activate(context: vscode.ExtensionContext) {
   const selector = ['perl', 'perl+mojolicious'];
-  function get_range(document: vscode.TextDocument, range: vscode.Range, selection: vscode.Selection) {
+  function get_range(document: vscode.TextDocument, range: vscode.Range | null, selection: vscode.Selection | null) {
     if (!(selection === null) && !selection.isEmpty) {
       range = new vscode.Range(selection.start, selection.end);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
    * @param range Range of text
    * @returns Returns the formatted text.
    * @throws {import('./error').FormatError} Throw an error if failed to format.
+   * @throws {unknown} Throw an error an unexpected problem has occurred.
    */
   function tidy(document: vscode.TextDocument, range: vscode.Range): Promise<string> {
     let text = document.getText(range);
@@ -105,6 +106,7 @@ export function activate(context: vscode.ExtensionContext) {
         });
       }
       catch (error) {
+        // internal error
         reject(error);
       }
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,7 +177,7 @@ export function activate(context: vscode.ExtensionContext) {
   }, ';', '}', ')', ']');
 
   let command = vscode.commands.registerCommand('perltidy-more.tidy', () => {
-    let editor = vscode.window.activeTextEditor;
+    const editor = vscode.window.activeTextEditor;
     if (!editor) {
       return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,8 @@ export function activate(context: vscode.ExtensionContext) {
         worker.stdout.on('data', (chunk) => {
           result_text += chunk;
         });
-        worker.stdout.on('end', () => {
+
+        worker.on('close', (code) => {
           resolve(result_text);
         });
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (config.get('autoDisable', false) && currentWorkspace != null) {
       if (!existsSync(join(currentWorkspace.uri.path, '.perltidyrc'))) {
-        return;
+        // Failed to format because `.perltidyrc` not found.
+        return Promise.resolve(undefined);
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": [
       "es6"
     ],
+    "strict": true,
     "sourceMap": true,
     "rootDir": "."
   },


### PR DESCRIPTION
depends: https://github.com/kak-tus/perltidy-more/pull/15 (Please review and merge after #15.)

## Problem
`spawn` will cause errors in various cases. When the process fails to start, when the started process terminates abnormally, and so on.

Currently, perltidy-more ignores all of these errors and does not notify the user when an error occurs. To make matters worse, when an error occurs, the formatted file is emptied.

https://user-images.githubusercontent.com/9639995/134809785-802fdf80-db7d-412d-8a46-9c60a9ba4bcc.mov


## Solution (This PR)
This PR handles these errors and notifies the user of the error in a dialog. In addition, it will skip formatting if an error occurs. This ensures that the file will not be empty when an error occurs.

## Confirm the operation
I have confirmed that the behavior is as expected in my environment.

- [x] The dialog is shown if perltidy command is missing.
- [x] The dialog is shown if an invalid `.perltidyrc` is passed.


<img width="1007" alt="スクリーンショット 2021-09-26 22 11 30" src="https://user-images.githubusercontent.com/9639995/134810118-def58126-deeb-4468-9315-fcd9196214bc.png">

<img width="1007" alt="スクリーンショット 2021-09-26 22 06 45" src="https://user-images.githubusercontent.com/9639995/134810131-5b7690c7-607b-48f8-b445-7d2700acae16.png">

